### PR TITLE
Remove unneeded packages from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,15 +13,13 @@ Description: R package for computing cell-type specific GWAS enrichments
 	from Finemapping data and quantitative epigenomic data. 
 Imports:
     methods,
-    BiocGenerics,
     BiocParallel,
     chromVAR,
-    chromVARmotifs,
-    motifmatchr,
     SummarizedExperiment,
     Matrix,
     GenomicRanges,
-    S4Vectors
+    S4Vectors,
+    stats
 License: MIT + file LICENSE
 LazyData: TRUE
 Suggests:


### PR DESCRIPTION
Just removing BiocGenerics, chromVARmotifs, motifmatchr and S4Vectors from the description as they're not actually used and installation will throw an error otherwise if they're not installed.